### PR TITLE
fix: 이전 링커 이미지 보이는 오류

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode }) => {
             },
             {
               urlPattern: ({ url }) => url.pathname.startsWith("/icons/category/"),
-              handler: "CacheFirst",
+              handler: "StaleWhileRevalidate",
               options: {
                 cacheName: "category-icons",
                 expiration: {


### PR DESCRIPTION
fix
- 캐시 설정으로 인해 간혹 이전 투명도 70% 링커 이미지가 보이는 오류 수정